### PR TITLE
Add Cloudflare IPv6 Trace Service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.10-slim
 
 RUN useradd --home-dir /app cfdns
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ Or you can use [the Docker image](https://hub.docker.com/r/kissgyorgy/cloudflare
 $ docker run --rm -it kissgyorgy/cloudflare-dyndns --help
 ```
 
+Please note that before you can use the `-6` IPv6 option in Docker, you need to [enable IPv6 support in the Docker daemon](https://docs.docker.com/config/daemon/ipv6/).
+Afterward, you can choose to use either IPv4 or IPv6 (or both) with any container, service, or network.
+
 # Note
 
 If you use this script, it "takes over" the handling of the record of those

--- a/cloudflare_dyndns/ip_services.py
+++ b/cloudflare_dyndns/ip_services.py
@@ -1,11 +1,11 @@
+from . import printer
 from cloudflare_dyndns.types import IPAddress
-import os
-import ipaddress
 from typing import Callable, List
 import attr
 import certifi
-from . import printer
-
+import ipaddress
+import os
+import requests
 
 # Workaround for certifi resource location doesn't work with PyOxidizer.
 # See: https://github.com/psf/requests/blob/v2.23.0/requests/utils.py#L40
@@ -13,7 +13,6 @@ from . import printer
 certifi.where = lambda: os.environ.get(
     "REQUESTS_CA_BUNDLE", "/etc/ssl/certs/ca-certificates.crt"
 )
-import requests
 
 
 class IPServiceError(Exception):
@@ -43,7 +42,7 @@ def parse_cloudflare_trace_ip(res: str) -> str:
     """
     for line in res.splitlines():
         if line.startswith("ip="):
-            ip = line[len("ip=") :]
+            ip = line[len("ip="):]
             return ip
 
 
@@ -61,19 +60,21 @@ class IPService:
 
 IPV4_SERVICES = [
     IPService(
-        "CloudFlare trace", "https://1.1.1.1/cdn-cgi/trace", parse_cloudflare_trace_ip,
+        "CloudFlare IPv4 trace", "https://1.1.1.1/cdn-cgi/trace", parse_cloudflare_trace_ip,
     ),
-    IPService("AWS check ip", "https://checkip.amazonaws.com/",),
-    IPService("major.io icanhazip", "http://ipv4.icanhazip.com/"),
-    IPService("Namecheap DynamicDNS", "https://dynamicdns.park-your-domain.com/getip",),
+    IPService("AWS check ip", "https://checkip.amazonaws.com/", ),
+    IPService("major.io icanhazip", "https://ipv4.icanhazip.com/"),
+    IPService("Namecheap DynamicDNS", "https://dynamicdns.park-your-domain.com/getip", ),
 ]
-
 
 IPV6_SERVICES = [
     # These are always return IPv6 addresses first, when the machine has IPv6
+    IPService(
+        "CloudFlare IPv6 trace", "https://[2606:4700:4700::1111]/cdn-cgi/trace", parse_cloudflare_trace_ip,
+    ),
     IPService("ip.tyk.nu", "https://ip.tyk.nu/"),
     IPService("wgetip.com", "https://wgetip.com/"),
-    IPService("major.io icanhazip", "http://ipv6.icanhazip.com/"),
+    IPService("major.io icanhazip", "https://ipv6.icanhazip.com/"),
 ]
 
 

--- a/tests/test_ip_services.py
+++ b/tests/test_ip_services.py
@@ -3,7 +3,7 @@ import pytest
 from cloudflare_dyndns import ip_services as ips
 
 
-def test_parse_cloudflare_trace_ip():
+def test_parse_cloudflare_trace_ipv4():
     trace_service_response = """fl=114f30
 h=1.1.1.1
 ip=199.12.81.4
@@ -18,6 +18,24 @@ sni=off
 warp=off
 """
     assert ips.parse_cloudflare_trace_ip(trace_service_response) == "199.12.81.4"
+
+
+def test_parse_cloudflare_trace_ipv6():
+    trace_service_response = """fl=75f49
+h=[2606:4700:4700::1111]
+ip=b322:31e3:f950:bad3:3589:8d9c:0812:c9c7
+ts=1651050273.63
+visit_scheme=https
+uag=Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36
+colo=VIE
+http=http/2
+loc=HU
+tls=TLSv1.3
+sni=off
+warp=off
+gateway=off
+"""
+    assert ips.parse_cloudflare_trace_ip(trace_service_response) == "b322:31e3:f950:bad3:3589:8d9c:0812:c9c7"
 
 
 @pytest.mark.parametrize("service", ips.IPV4_SERVICES)


### PR DESCRIPTION
The following changes have been made:

- Add Cloudflare IPv6 trace service (https://[2606:4700:4700::1111]/cdn-cgi/trace)
- Add Cloudflare IPv6 trace service test
- Require all ip services to use HTTPS
- Add note to README.md that Docker does not support the IPv6 option by default
- Update Python to version 3.10 in Dockerfile
- Add \_\_init\_\_.py to tests directory