### PR TITLE
Fix: allow api token files that end with newline

### DIFF
--- a/cloudflare_dyndns/cli.py
+++ b/cloudflare_dyndns/cli.py
@@ -45,7 +45,7 @@ def parse_api_token_args(
     if api_token is not None:
         return api_token
     elif api_token_file is not None:
-        return api_token_file.read_text()
+        return api_token_file.read_text().rstrip()
     else:
         raise click.BadArgumentUsage(
             "You have to specify an api token; use --api-token or --api-token-file."


### PR DESCRIPTION
After updating from 5.0 to 5.3 (on NixOS), I started getting this error:

```
Loading cache from: /var/lib/cloudflare-dyndns/ip.cache
Cache file not found.
Checking current IPv4 address with service: ipify API (https://api.ipify.org)
Current IP address: [CENSORED IP]
Unknown error: Illegal header value b'Bearer [CENSORED TOKEN]\n'
There were errors during update.
Deleting cache at: /var/lib/cloudflare-dyndns/ip.cache
```

This happens because my secrets managing tool always puts a newline at the end of the file.
Version 5.0 seemed to deal with this somehow, but 5.3 includes the newline, causing errors in the Cloudflare API.

I have tested this change, and it fixes the problem for me, and I believe it shouldn't break anything for other users.

Also, as a side note: the above error still resulted in a `0` exit code, but I'm not sure how to fix that.
