### PR TITLE
fix: Delete cache when all IP service lookups fail with --delete-missing

### DIFF
--- a/cloudflare_dyndns/cli.py
+++ b/cloudflare_dyndns/cli.py
@@ -185,7 +185,7 @@ def main(
     old_cache, new_cache = cache_manager.load()
 
     updater = CFUpdater(
-        domains, cf, old_cache, new_cache, force, delete_missing, proxied, debug
+        domains, cf, old_cache, new_cache, force, delete_missing, proxied, debug, cache_manager
     )
 
     exit_codes = set()


### PR DESCRIPTION
When using `--delete-missing` flag and all IP services fail, DNS records are deleted but the cache remained stale. This caused issues on the next run where the cached IP would prevent DNS record recreation if the IP hadn't changed.

Fixes #46
